### PR TITLE
Fix example and code related to #2

### DIFF
--- a/jsref.go
+++ b/jsref.go
@@ -37,6 +37,7 @@ type resolveCtx struct {
 //    [scheme:opaque[?query]]#fragment
 //
 // where everything except for `#fragment` is optional.
+// If the fragment is empty, an error is returned.
 //
 // If `spec` is the empty string, `v` is returned
 // This method handles recursive JSON references.
@@ -206,6 +207,13 @@ func evalptr(ctx resolveCtx, r *Resolver, v interface{}, ptrspec string) (ret in
 	}
 
 	ptr := u.Fragment
+
+	// We are evaluating the pointer part. That means if the
+	// Fragment portion is not set, there's no point in evaluating
+	if ptr == "" {
+		return nil, errors.Wrap(err, "empty json pointer")
+	}
+
 	p, err := jspointer.New(ptr)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed create a new JSON pointer")

--- a/jsref_example_test.go
+++ b/jsref_example_test.go
@@ -1,0 +1,52 @@
+package jsref_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	jsref "github.com/lestrrat/go-jsref"
+	"github.com/lestrrat/go-jsref/provider"
+)
+
+func Example() {
+	var v interface{}
+	src := []byte(`
+{
+  "foo": ["bar", {"$ref": "#/sub"}, {"$ref": "obj2#/sub"}],
+  "sub": "baz"
+}`)
+	if err := json.Unmarshal(src, &v); err != nil {
+		log.Printf("%s", err)
+		return
+	}
+
+	// External reference
+	mp := provider.NewMap()
+	mp.Set("obj2", map[string]string{"sub": "quux"})
+
+	res := jsref.New()
+	res.AddProvider(mp) // Register the provider
+
+	ptrs := []string{
+		"#/foo/0", // "bar"
+		"#/foo/1", // "baz"
+		"#/foo/2", // "quux" (resolves via `mp`)
+		"#/foo",   // contents of foo key
+	}
+	for _, ptr := range ptrs {
+		result, err := res.Resolve(v, ptr)
+		if err != nil { // failed to resolve
+			fmt.Printf("err: %s\n", err)
+			continue
+		}
+		b, _ := json.Marshal(result)
+		fmt.Printf("%s -> %s\n", ptr, string(b))
+	}
+
+	// OUTPUT:
+	// #/foo/0 -> "bar"
+	// #/foo/1 -> "baz"
+	// #/foo/2 -> "quux"
+	// #/foo -> ["bar",{"$ref":"#/sub"},{"$ref":"obj2#/sub"}]
+}

--- a/jsref_test.go
+++ b/jsref_test.go
@@ -181,3 +181,24 @@ func TestResolveRecursive(t *testing.T) {
 		return
 	}
 }
+
+func TestGHPR12(t *testing.T) {
+	// https://github.com/lestrrat/go-jsref/pull/2 gave me an example
+	// using "foo" as the JS pointer (could've been a typo)
+	// but it gave me weird results, so this is where I'm testing it
+	var v interface{}
+	src := []byte(`
+{
+	"foo": "bar"
+}`)
+	if err := json.Unmarshal(src, &v); err != nil {
+		log.Printf("%s", err)
+		return
+	}
+
+	res := jsref.New()
+	_, err := res.Resolve(v, "foo")
+	if !assert.NoError(t, err, "res.Resolve should fail") {
+		return
+	}
+}

--- a/jsref_test.go
+++ b/jsref_test.go
@@ -18,30 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Example() {
-	var v interface{}
-	src := []byte(`
-{
-  "foo": ["bar", {"$ref": "#/sub"}, {"$ref", "obj2#/sub"}],
-  "sub": "baz"
-}`)
-	if err := json.Unmarshal(src, &v); err != nil {
-		log.Printf("%s", err)
-		return
-	}
-
-	// External reference
-	mp := provider.NewMap()
-	mp.Set("obj2", map[string]string{"sub": "quux"})
-
-	res := jsref.New()
-	res.AddProvider(mp) // Register the provider
-
-	res.Resolve(v, "#/foo/0") // "bar"
-	res.Resolve(v, "#/foo/1") // "baz"
-	res.Resolve(v, "#/foo/2") // "quux" (resolve via `mp`)
-}
-
 func TestResolveMemory(t *testing.T) {
 	m := map[string]interface{}{
 		"foo": []interface{}{


### PR DESCRIPTION
* Update `Example()` with actual output to compare against.
* Update README with said code above.
* Clarify that Resolve() must take a spec with non-empty fragment, update tests

fixes #2